### PR TITLE
Test and document error diagnostics; add DataSeries relative_norm_error

### DIFF
--- a/src/GeometricSolutions.jl
+++ b/src/GeometricSolutions.jl
@@ -2,6 +2,7 @@ module GeometricSolutions
 
 using GeometricBase
 using GeometricEquations
+using LinearAlgebra: norm
 using Test
 
 using Base: TwicePrecision

--- a/src/dataseries.jl
+++ b/src/dataseries.jl
@@ -79,7 +79,46 @@ function Base.Array(ds::DataSeries)
     return z
 end
 
+# Relative maximum error of a single point. If the point-wise absolute error
+# vanishes (e.g. an all-zero reference point that is matched exactly) the relative
+# error is zero, avoiding the 0/0 = NaN that dividing by a zero norm would produce.
+function _relative_maximum_error(sol, ref)
+    err = maximum_error(sol, ref)
+    iszero(err) ? err : err / maximum(abs.(ref))
+end
+
+"""
+Computes the maximum over time of the relative maximum error between two DataSeries.
+
+Arguments: `(ds::DataSeries, ref::DataSeries)`
+
+For each time step the relative error `maximum_error(ds[i], ref[i]) / maximum(abs.(ref[i]))`
+is evaluated, i.e. each point is normalized by its own maximum absolute value. Returns the
+maximum of these per-step errors. An all-zero reference point matched exactly has a vanishing
+point-wise error and therefore contributes `0` rather than `0/0 = NaN`.
+"""
 function relative_maximum_error(ds::DataSeries, ref::DataSeries)
     @assert axes(ds.d) == axes(ref.d)
-    maximum(maximum_error.(ds.d, ref.d) ./ [maximum(abs.(d)) for d in ref.d])
+    maximum(_relative_maximum_error.(ds.d, ref.d))
+end
+
+# Relative p-norm error of a single point. As above, a vanishing absolute norm
+# error (e.g. an all-zero reference point matched exactly) yields zero instead of
+# the 0/0 = NaN that dividing by a zero norm would produce.
+function _relative_norm_error(sol, ref, p = 2)
+    err = norm(sol .- ref, p)
+    iszero(err) ? err : err / norm(ref, p)
+end
+
+"""
+Computes the time trace of the relative `p`-norm error between two DataSeries.
+
+Arguments: `(ds::DataSeries, ref::DataSeries, p = 2)`
+
+For each time step the relative error `norm(ds[i] - ref[i], p) / norm(ref[i], p)`
+is evaluated. Returns a `ScalarDataSeries` holding this time series.
+"""
+function relative_norm_error(ds::DataSeries, ref::DataSeries, p = 2)
+    @assert axes(ds.d) == axes(ref.d)
+    DataSeries([_relative_norm_error(d, r, p) for (d, r) in zip(ds.d, ref.d)])
 end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,15 +1,39 @@
 
+"""
+Computes the relative `p`-norm error between a solution and a reference.
+
+Arguments: `(sol, ref, p = 2)`
+
+Returns `norm(sol .- ref, p) / norm(ref, p)`, i.e. the `p`-norm of the difference
+normalized by the `p`-norm of the reference.
+"""
 function relative_norm_error(sol, ref, p = 2)
     norm(sol .- ref, p) / norm(ref, p)
 end
 
+"""
+Computes the maximum absolute error between a solution and a reference.
+
+Arguments: `(sol, ref)`
+
+Returns `maximum(abs.(sol .- ref))`, the largest absolute component-wise difference.
+"""
 function maximum_error(sol, ref)
     maximum(abs.(sol .- ref))
 end
 
+"""
+Computes the relative maximum error between a solution and a reference.
+
+Arguments: `(sol, ref)`
+
+Returns `maximum_error(sol, ref) / maximum(abs.(ref))`, i.e. the maximum absolute
+error normalized by the maximum absolute value of the reference.
+"""
 function relative_maximum_error(sol, ref)
     maximum_error(sol, ref) / maximum(abs.(ref))
 end
+
 
 """
 Computes the difference of two DataSeries.

--- a/test/diagnostics_tests.jl
+++ b/test/diagnostics_tests.jl
@@ -91,3 +91,128 @@ end
 ϑe = compute_momentum_error(sol)
 
 @test parent(ϑe) == OffsetArray([zeros(dt, nd) for _ in 1:(nt + 1)], 0:nt)
+
+
+# Norm and maximum errors
+
+# relative_norm_error operates via `norm`, which recurses into arrays, so it
+# accepts both plain numeric arrays and arrays of vector-valued points (one vector
+# per time step). It does not support DataSeries.
+
+# Identity: solution equals reference => error vanishes
+nref = OffsetArray([dt[1.0, 2.0], dt[3.0, 4.0], dt[5.0, 6.0]], 0:2)
+
+@test relative_norm_error(nref, nref) == 0
+
+# Known nonzero value (differences chosen for an exact, checkable result)
+nsol = OffsetArray([dt[1.0, 2.0], dt[3.0, 5.0], dt[7.0, 6.0]], 0:2)
+
+@test relative_norm_error(nsol, nref) ≈ sqrt(5) / sqrt(91)
+
+# p-norm argument (numeric vectors give the standard p-norms)
+psol = dt[1.0, 2.0, 3.0]
+pref = dt[1.0, 4.0, 3.0]
+
+@test relative_norm_error(psol, pref) ≈ 2.0 / sqrt(26)     # default p = 2
+@test relative_norm_error(psol, pref, 1) == 2.0 / 8.0      # p = 1
+@test relative_norm_error(psol, pref, Inf) == 2.0 / 4.0    # p = ∞
+
+# Solution points where all components are zero: some points of both sol and ref
+# are the zero vector, but ref is not entirely zero, so the denominator stays nonzero.
+znref = OffsetArray([dt[0.0, 0.0], dt[1.0, 2.0], dt[0.0, 0.0], dt[3.0, 4.0]], 0:3)
+znsol = OffsetArray([dt[0.0, 0.0], dt[1.5, 2.0], dt[0.0, 0.0], dt[3.0, 4.0]], 0:3)
+
+@test relative_norm_error(znsol, znref) ≈ 0.5 / sqrt(30)
+
+# Zero points only in sol (ref has none): still no error, correct value
+znref2 = OffsetArray([dt[1.0, 1.0], dt[2.0, 2.0], dt[4.0, 4.0]], 0:2)
+znsol2 = OffsetArray([dt[0.0, 0.0], dt[2.0, 2.0], dt[4.0, 4.0]], 0:2)
+
+@test relative_norm_error(znsol2, znref2) ≈ sqrt(2) / sqrt(42)
+
+
+# maximum_error and relative_maximum_error operate via `abs.(sol .- ref)`, so the
+# generic methods take plain numeric arrays (or a ScalarDataSeries); each element
+# is treated as a scalar component.
+
+# Identity: error vanishes
+va = dt[1.0, 2.0, 3.0]
+
+@test maximum_error(va, va) == 0
+@test relative_maximum_error(va, va) == 0
+
+# Known nonzero values
+@test maximum_error(psol, pref) == 2.0
+@test relative_maximum_error(psol, pref) == 2.0 / 4.0
+
+# A matrix argument works the same way
+@test maximum_error(dt[1 2; 3 4], dt[1 2; 3 6]) == 2.0
+@test relative_maximum_error(dt[1 2; 3 4], dt[1 2; 3 6]) == 2.0 / 6.0
+
+# Components equal to zero: some entries of sol and ref are zero, ref is not all zero
+vzref = dt[0.0, 2.0, 0.0, 5.0]
+vzsol = dt[0.0, 3.0, 0.0, 5.0]
+
+@test maximum_error(vzsol, vzref) == 1.0                   # zero components contribute nothing
+@test relative_maximum_error(vzsol, vzref) == 1.0 / 5.0    # divided by max abs component of ref
+
+# ScalarDataSeries with points equal to zero. maximum_error uses the generic method,
+# while relative_maximum_error dispatches to the DataSeries method that normalizes
+# each point individually; a zero point matched exactly contributes 0 (not 0/0 = NaN).
+sref = DataSeries(OffsetArray(dt[0.0, 2.0, 0.0, 3.0], 0:3))
+ssol = DataSeries(OffsetArray(dt[0.0, 1.0, 0.0, 3.0], 0:3))
+
+@test maximum_error(ssol, sref) == 1.0
+@test relative_maximum_error(ssol, sref) == 1.0 / 2.0
+@test !isnan(relative_maximum_error(ssol, sref))
+
+
+# relative_maximum_error for a DataSeries of vector-valued points dispatches to the
+# dedicated DataSeries method (src/dataseries.jl), which normalizes each point by
+# its own maximum and takes the maximum of the per-point relative errors.
+vref = OffsetArray([dt[1.0, 2.0], dt[3.0, 4.0], dt[5.0, 6.0]], 0:2)
+vsol = OffsetArray([dt[1.0, 2.0], dt[3.0, 5.0], dt[7.0, 6.0]], 0:2)
+
+@test relative_maximum_error(DataSeries(vsol), DataSeries(vref)) == 2.0 / 6.0
+
+# All-zero solution points: a zero reference point matched exactly must contribute 0
+# rather than 0/0 = NaN.
+vzr = OffsetArray([dt[0.0, 0.0], dt[1.0, 2.0], dt[0.0, 0.0], dt[3.0, 4.0]], 0:3)
+vzs = OffsetArray([dt[0.0, 0.0], dt[1.5, 2.0], dt[0.0, 0.0], dt[3.0, 4.0]], 0:3)
+
+@test relative_maximum_error(DataSeries(vzs), DataSeries(vzr)) == 0.5 / 2.0
+@test !isnan(relative_maximum_error(DataSeries(vzs), DataSeries(vzr)))
+
+
+# relative_norm_error for two DataSeries returns a ScalarDataSeries holding the
+# time trace of the per-step relative p-norm error.
+rne = relative_norm_error(DataSeries(vsol), DataSeries(vref))
+
+@test typeof(rne) <: ScalarDataSeries{dt}
+@test axes(rne) == axes(DataSeries(vref))
+@test rne[0] == 0.0                                        # sol == ref at step 0
+@test rne[1] ≈ 1.0 / 5.0                                   # norm([0,1]) / norm([3,4])
+@test rne[2] ≈ 2.0 / sqrt(61)                              # norm([2,0]) / norm([5,6])
+
+# The p-norm argument is forwarded to each step
+rne1 = relative_norm_error(DataSeries(vsol), DataSeries(vref), 1)
+
+@test typeof(rne1) <: ScalarDataSeries{dt}
+@test rne1[1] == 1.0 / 7.0                                 # norm([0,1],1) / norm([3,4],1)
+
+# All-zero reference points matched exactly contribute 0, not 0/0 = NaN
+rnez = relative_norm_error(DataSeries(vzs), DataSeries(vzr))
+
+@test typeof(rnez) <: ScalarDataSeries{dt}
+@test rnez[0] == 0.0
+@test rnez[1] ≈ 0.5 / sqrt(5)
+@test rnez[2] == 0.0
+@test rnez[3] == 0.0
+@test all(!isnan, parent(rnez))
+
+# Also works for a ScalarDataSeries (scalar-valued points)
+srne = relative_norm_error(ssol, sref)
+
+@test typeof(srne) <: ScalarDataSeries{dt}
+@test srne[1] == 1.0 / 2.0
+@test all(!isnan, parent(srne))


### PR DESCRIPTION
## Summary

Adds test coverage and documentation for the error-diagnostics functions, fixes a latent bug, and extends the `DataSeries` API.

- **Tests** (`test/diagnostics_tests.jl`): direct tests for `relative_norm_error`, `maximum_error`, and `relative_maximum_error`, including cases where solution points have all components equal to zero. Diagnostics test set grows from 24 to 60 assertions.
- **Bug fix** (`src/GeometricSolutions.jl`): `relative_norm_error` threw `UndefVarError(:norm)` because `LinearAlgebra.norm` was never imported into the module (it went unnoticed as the function had no test). Added `using LinearAlgebra: norm`. `LinearAlgebra` was already a `Project.toml` dependency.
- **Hardening** (`src/dataseries.jl`): `relative_maximum_error(::DataSeries, ::DataSeries)` now treats an all-zero reference point matched exactly as `0` instead of computing `0/0 = NaN`.
- **New method** (`src/dataseries.jl`): `relative_norm_error(::DataSeries, ::DataSeries, p = 2)` returns a `ScalarDataSeries` holding the per-step relative `p`-norm error time trace, with the same zero-point hardening.
- **Docstrings**: added for the generic error functions in `src/diagnostics.jl` and for the `DataSeries` methods in `src/dataseries.jl`.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — full suite passes (Data Series 76, Time Series 31, Solution 32, Diagnostics 60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)